### PR TITLE
chore: shorter line lengths in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ use default_aware::DefaultAware;
 use serde::{self, Deserialize};
 use serde_json;
 
-// This represents some value you might deserialize, which implements the `Default` trait.
+// This represents some value you might deserialize, which
+// implements the `Default` trait.
 #[derive(Deserialize, PartialEq, Debug)]
 struct Port(u32);
 
@@ -37,39 +38,49 @@ pub struct MyConfig {
 
 fn main() {
 
-    // The first config sets the port number to the same as the default. If we weren't
-    // using the `DefaultAware` wrapper, the value recieved after deserializing would be
-    // indistinguishable from the default value. Therefore we could not know if the
-    // `http_port` field was actually provided in the document or not.
+    // The first config sets the port number to the same as the
+    // default. If we weren't using the `DefaultAware` wrapper, the
+    // value recieved after deserializing would be
+    // indistinguishable from the default value. Therefore we could
+    // not know if the `http_port` field was actually provided in
+    // the document or not.
     let config1_json: &str = r#"{ "http_port": 8000 }"#;
 
-    // But since we are using the `DefaultAware` wrapper, we can easily tell that the value
-    // was not created via the `Default` implementation.
-    let config1: MyConfig = serde_json::from_str(config1_json).unwrap();
+    // But since we are using the `DefaultAware` wrapper, we can
+    // easily tell that the value was not created via the `Default`
+    // implementation.
+    let config1: MyConfig = serde_json::from_str(config1_json)
+        .unwrap();
     assert_eq!(false, config1.http_port.is_default());
     assert_eq!(Port(8000), config1.http_port.unwrap());
 
 
-    // We can demonstrate the behavior when the default value is used by checking the output
+    // We can demonstrate the behavior when the default value is
+    // used by checking the output
     // on a document that omits the `http_port` field.
     const config2_json: &str = r#"{  }"#;
 
-    // The field has the same wrapped value as before, but notice that we tell it
-    // was created via the Default implementation.
+    // The field has the same wrapped value as before, but notice
+    // that we tell it was created via the Default implementation.
 
-    let config2: MyConfig = serde_json::from_str(config2_json).unwrap();
+    let config2: MyConfig = serde_json::from_str(config2_json)
+        .unwrap();
     assert_eq!(Port(8000), *config2.http_port.as_ref());
     assert_eq!(true, config2.http_port.is_default());
 
-    // The type is just an enun, so we can use all the typical enum patterns
+    // The type is just an enun, so we can use all the typical enum
+    // patterns
     match config2.http_port {
-        DefaultAware::Default(_) => println!("value set by default"),
-        DefaultAware::Declared(_) => println!("value set in the config"),
+        DefaultAware::Default(_) =>
+            println!("value set by default"),
+        DefaultAware::Declared(_) =>
+            println!("value set in the config"),
     }
 
     if let DefaultAware::Default(_) = config2.http_port {
-        println!("Port number not set! Running on port 8000 by default. Silence this \
-            warning by setting the `http_port` field in your config.");
+        println!("Port number not set! Running on port 8000 by \
+            default. Silence this warning by setting the \
+            `http_port` field in your config.");
     }
 }
 ```


### PR DESCRIPTION
means the code block displays cleaner on crates.io